### PR TITLE
Fix audio capture start

### DIFF
--- a/src/AudioCapture.cpp
+++ b/src/AudioCapture.cpp
@@ -34,8 +34,10 @@ bool AudioCapture::start() {
     WAVEFORMATEX* pwfx = nullptr;
     hr = m_audioClient->GetMixFormat(&pwfx);
     if (FAILED(hr)) return false;
+    DWORD streamFlags = m_loopback ? AUDCLNT_STREAMFLAGS_LOOPBACK : 0;
+    streamFlags |= AUDCLNT_STREAMFLAGS_EVENTCALLBACK;
     hr = m_audioClient->Initialize(AUDCLNT_SHAREMODE_SHARED,
-                                   m_loopback ? AUDCLNT_STREAMFLAGS_LOOPBACK : 0,
+                                   streamFlags,
                                    0, 0, pwfx, nullptr);
     if (FAILED(hr)) return false;
     hr = m_audioClient->GetService(IID_PPV_ARGS(&m_captureClient));


### PR DESCRIPTION
## Summary
- fix audio capture startup by enabling event callback

## Testing
- `g++ src/*.cpp -Iinclude -o live -std=c++17` *(fails: conio.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_688b1e21d848832a99337282c7f0fab2