### PR TITLE
Fix distorted audio due to incorrect format assumptions

### DIFF
--- a/include/AudioCapture.h
+++ b/include/AudioCapture.h
@@ -21,6 +21,10 @@ public:
 
     AudioBuffer& buffer();
 
+    int sampleRate() const { return m_sampleRate; }
+    short channels() const { return m_channels; }
+    short bitsPerSample() const { return m_bitsPerSample; }
+
 private:
     void captureThread();
 
@@ -29,6 +33,11 @@ private:
     std::atomic<bool> m_running{false};
 
     AudioBuffer m_buffer;
+
+    int m_sampleRate = 0;
+    short m_channels = 0;
+    short m_bitsPerSample = 0;
+    short m_blockAlign = 0;
 
 #ifdef _WIN32
     IMMDevice* m_device = nullptr;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -14,17 +14,21 @@ int main() {
     }
     std::cout << "Press 's' to save last N seconds, 'q' to quit" << std::endl;
     const double secondsToSave = 10.0; // change as needed
-    const int sampleRate = 44100;
-    const short channels = 2;
-    const short bits = 16;
+    const int sysRate = systemCap.sampleRate();
+    const short sysChannels = systemCap.channels();
+    const short sysBits = systemCap.bitsPerSample();
+
+    const int micRate = micCap.sampleRate();
+    const short micChannels = micCap.channels();
+    const short micBits = micCap.bitsPerSample();
     while (true) {
         int ch = _getch();
         if (ch == 'q') break;
         if (ch == 's') {
-            auto sysData = systemCap.buffer().getLastSamples(secondsToSave, sampleRate * channels * bits / 8);
-            auto micData = micCap.buffer().getLastSamples(secondsToSave, sampleRate * channels * bits / 8);
-            WavWriter::writeWav("system.wav", sysData, sampleRate, channels, bits);
-            WavWriter::writeWav("mic.wav", micData, sampleRate, channels, bits);
+            auto sysData = systemCap.buffer().getLastSamples(secondsToSave, sysRate * sysChannels * sysBits / 8);
+            auto micData = micCap.buffer().getLastSamples(secondsToSave, micRate * micChannels * micBits / 8);
+            WavWriter::writeWav("system.wav", sysData, sysRate, sysChannels, sysBits);
+            WavWriter::writeWav("mic.wav", micData, micRate, micChannels, micBits);
             std::cout << "Saved" << std::endl;
         }
     }


### PR DESCRIPTION
## Summary
- track actual audio format in `AudioCapture`
- size the buffer after discovering the format
- push captured frames based on the correct block size
- expose format getters and use them when writing WAV files

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_688b1f9edf0c832a9d0abb71669f15be