### PR TITLE
Fix AudioBuffer assignment build error

### DIFF
--- a/include/AudioBuffer.h
+++ b/include/AudioBuffer.h
@@ -7,6 +7,8 @@
 class AudioBuffer {
 public:
     AudioBuffer(size_t maxSamples = 0);
+    // Adjust the internal capacity. This clears existing contents.
+    void setCapacity(size_t maxSamples);
     void push(const void* data, size_t bytes);
     std::vector<char> getLastSamples(double seconds, int bytesPerSecond) const;
 

--- a/src/AudioBuffer.cpp
+++ b/src/AudioBuffer.cpp
@@ -4,6 +4,13 @@
 AudioBuffer::AudioBuffer(size_t maxSamples)
     : m_buffer(maxSamples), m_capacity(maxSamples) {}
 
+void AudioBuffer::setCapacity(size_t maxSamples) {
+    std::lock_guard<std::mutex> lock(m_mutex);
+    m_buffer.assign(maxSamples, 0);
+    m_capacity = maxSamples;
+    m_writePos = 0;
+}
+
 void AudioBuffer::push(const void* data, size_t bytes) {
     std::lock_guard<std::mutex> lock(m_mutex);
     const char* ptr = static_cast<const char*>(data);

--- a/src/AudioCapture.cpp
+++ b/src/AudioCapture.cpp
@@ -41,7 +41,8 @@ bool AudioCapture::start() {
     m_blockAlign = pwfx->nBlockAlign;
 
     size_t bytesPerSecond = static_cast<size_t>(m_sampleRate) * m_blockAlign;
-    m_buffer = AudioBuffer(bytesPerSecond * 3600 * 10); // 10h buffer
+    // Prepare a large enough buffer to hold up to 10 hours of audio.
+    m_buffer.setCapacity(bytesPerSecond * 3600 * 10);
     DWORD streamFlags = m_loopback ? AUDCLNT_STREAMFLAGS_LOOPBACK : 0;
     streamFlags |= AUDCLNT_STREAMFLAGS_EVENTCALLBACK;
     hr = m_audioClient->Initialize(AUDCLNT_SHAREMODE_SHARED,


### PR DESCRIPTION
## Summary
- avoid assigning AudioBuffer to work around deleted assignment operator
- add `setCapacity` helper in `AudioBuffer`
- use `setCapacity` when initializing buffer in `AudioCapture`

## Testing
- `x86_64-w64-mingw32-g++ -std=c++17 -Iinclude src/*.cpp -o live.exe` *(fails: Functiondiscoverykeys_devpkey.h not found)*

------
https://chatgpt.com/codex/tasks/task_e_688b219d104c832abcb25b33160cd70f