### PR TITLE
Fix audio format handling

### DIFF
--- a/include/AudioCapture.h
+++ b/include/AudioCapture.h
@@ -24,6 +24,7 @@ public:
     int sampleRate() const { return m_sampleRate; }
     short channels() const { return m_channels; }
     short bitsPerSample() const { return m_bitsPerSample; }
+    short formatType() const { return m_formatType; }
 
 private:
     void captureThread();
@@ -38,6 +39,7 @@ private:
     short m_channels = 0;
     short m_bitsPerSample = 0;
     short m_blockAlign = 0;
+    short m_formatType = 1;
 
 #ifdef _WIN32
     IMMDevice* m_device = nullptr;

--- a/include/WavWriter.h
+++ b/include/WavWriter.h
@@ -10,7 +10,8 @@ public:
                          const std::vector<char>& data,
                          int sampleRate,
                          short channels,
-                         short bitsPerSample);
+                         short bitsPerSample,
+                         short formatType);
 };
 
 #endif // WAV_WRITER_H

--- a/src/AudioCapture.cpp
+++ b/src/AudioCapture.cpp
@@ -5,6 +5,7 @@
 #include <Functiondiscoverykeys_devpkey.h>
 #include <mmdeviceapi.h>
 #include <Audioclient.h>
+#include <mmreg.h>
 #include <comdef.h>
 #pragma comment(lib, "ole32.lib")
 #pragma comment(lib, "winmm.lib")
@@ -39,6 +40,17 @@ bool AudioCapture::start() {
     m_channels = pwfx->nChannels;
     m_bitsPerSample = pwfx->wBitsPerSample;
     m_blockAlign = pwfx->nBlockAlign;
+    m_formatType = pwfx->wFormatTag;
+#ifdef _WIN32
+    if (pwfx->wFormatTag == WAVE_FORMAT_EXTENSIBLE) {
+        WAVEFORMATEXTENSIBLE* ext = reinterpret_cast<WAVEFORMATEXTENSIBLE*>(pwfx);
+        if (ext->SubFormat == KSDATAFORMAT_SUBTYPE_IEEE_FLOAT) {
+            m_formatType = WAVE_FORMAT_IEEE_FLOAT;
+        } else if (ext->SubFormat == KSDATAFORMAT_SUBTYPE_PCM) {
+            m_formatType = WAVE_FORMAT_PCM;
+        }
+    }
+#endif
 
     size_t bytesPerSecond = static_cast<size_t>(m_sampleRate) * m_blockAlign;
     // Prepare a large enough buffer to hold up to 10 hours of audio.

--- a/src/WavWriter.cpp
+++ b/src/WavWriter.cpp
@@ -22,7 +22,8 @@ bool WavWriter::writeWav(const std::string& path,
                          const std::vector<char>& data,
                          int sampleRate,
                          short channels,
-                         short bitsPerSample) {
+                         short bitsPerSample,
+                         short formatType) {
     WavHeader header;
     header.data_size = data.size();
     header.overall_size = header.data_size + sizeof(WavHeader) - 8;
@@ -31,6 +32,7 @@ bool WavWriter::writeWav(const std::string& path,
     header.byterate = sampleRate * channels * bitsPerSample / 8;
     header.block_align = channels * bitsPerSample / 8;
     header.bits_per_sample = bitsPerSample;
+    header.format_type = formatType;
 
     std::ofstream ofs(path, std::ios::binary);
     if (!ofs) return false;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -17,18 +17,20 @@ int main() {
     const int sysRate = systemCap.sampleRate();
     const short sysChannels = systemCap.channels();
     const short sysBits = systemCap.bitsPerSample();
+    const short sysFormat = systemCap.formatType();
 
     const int micRate = micCap.sampleRate();
     const short micChannels = micCap.channels();
     const short micBits = micCap.bitsPerSample();
+    const short micFormat = micCap.formatType();
     while (true) {
         int ch = _getch();
         if (ch == 'q') break;
         if (ch == 's') {
             auto sysData = systemCap.buffer().getLastSamples(secondsToSave, sysRate * sysChannels * sysBits / 8);
             auto micData = micCap.buffer().getLastSamples(secondsToSave, micRate * micChannels * micBits / 8);
-            WavWriter::writeWav("system.wav", sysData, sysRate, sysChannels, sysBits);
-            WavWriter::writeWav("mic.wav", micData, micRate, micChannels, micBits);
+            WavWriter::writeWav("system.wav", sysData, sysRate, sysChannels, sysBits, sysFormat);
+            WavWriter::writeWav("mic.wav", micData, micRate, micChannels, micBits, micFormat);
             std::cout << "Saved" << std::endl;
         }
     }


### PR DESCRIPTION
## Summary
- expose capture format type to callers
- preserve original format when writing WAV files
- save format info from system and microphone capture

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_688b236a8b2c832a864d1750006f6770