### PR TITLE
Optimize memory usage

### DIFF
--- a/include/AudioBuffer.h
+++ b/include/AudioBuffer.h
@@ -2,6 +2,7 @@
 #define AUDIO_BUFFER_H
 
 #include <vector>
+#include <deque>
 #include <mutex>
 
 class AudioBuffer {
@@ -14,8 +15,7 @@ public:
 
 private:
     mutable std::mutex m_mutex;
-    std::vector<char> m_buffer;
-    size_t m_writePos = 0;
+    std::deque<char> m_buffer;
     size_t m_capacity = 0;
 };
 

--- a/src/AudioBuffer.cpp
+++ b/src/AudioBuffer.cpp
@@ -1,33 +1,33 @@
 #include "AudioBuffer.h"
 #include <cstring>
+#include <algorithm>
 
 AudioBuffer::AudioBuffer(size_t maxSamples)
-    : m_buffer(maxSamples), m_capacity(maxSamples) {}
+    : m_capacity(maxSamples) {}
 
 void AudioBuffer::setCapacity(size_t maxSamples) {
     std::lock_guard<std::mutex> lock(m_mutex);
-    m_buffer.assign(maxSamples, 0);
+    m_buffer.clear();
     m_capacity = maxSamples;
-    m_writePos = 0;
 }
 
 void AudioBuffer::push(const void* data, size_t bytes) {
     std::lock_guard<std::mutex> lock(m_mutex);
     const char* ptr = static_cast<const char*>(data);
     for (size_t i = 0; i < bytes; ++i) {
-        m_buffer[m_writePos] = ptr[i];
-        m_writePos = (m_writePos + 1) % m_capacity;
+        m_buffer.push_back(ptr[i]);
+    }
+    while (m_buffer.size() > m_capacity) {
+        m_buffer.pop_front();
     }
 }
 
 std::vector<char> AudioBuffer::getLastSamples(double seconds, int bytesPerSecond) const {
     std::lock_guard<std::mutex> lock(m_mutex);
     size_t bytesNeeded = static_cast<size_t>(seconds * bytesPerSecond);
-    if (bytesNeeded > m_capacity) bytesNeeded = m_capacity;
+    if (bytesNeeded > m_buffer.size()) bytesNeeded = m_buffer.size();
     std::vector<char> out(bytesNeeded);
-    size_t start = (m_writePos + m_capacity - bytesNeeded) % m_capacity;
-    for (size_t i = 0; i < bytesNeeded; ++i) {
-        out[i] = m_buffer[(start + i) % m_capacity];
-    }
+    auto startIt = m_buffer.end() - bytesNeeded;
+    std::copy(startIt, m_buffer.end(), out.begin());
     return out;
 }

--- a/src/AudioCapture.cpp
+++ b/src/AudioCapture.cpp
@@ -53,8 +53,9 @@ bool AudioCapture::start() {
 #endif
 
     size_t bytesPerSecond = static_cast<size_t>(m_sampleRate) * m_blockAlign;
-    // Prepare a large enough buffer to hold up to 10 hours of audio.
-    m_buffer.setCapacity(bytesPerSecond * 3600 * 10);
+    // Only keep a reasonable history (e.g. last 60 seconds) to avoid huge memory usage.
+    const double bufferSeconds = 60.0; // adjust as needed
+    m_buffer.setCapacity(static_cast<size_t>(bytesPerSecond * bufferSeconds));
     DWORD streamFlags = m_loopback ? AUDCLNT_STREAMFLAGS_LOOPBACK : 0;
     streamFlags |= AUDCLNT_STREAMFLAGS_EVENTCALLBACK;
     hr = m_audioClient->Initialize(AUDCLNT_SHAREMODE_SHARED,

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -2,7 +2,9 @@
 #include "MicCapture.h"
 #include "WavWriter.h"
 #include <iostream>
+#ifdef _WIN32
 #include <conio.h>
+#endif
 
 int main() {
 #ifdef _WIN32


### PR DESCRIPTION
## Summary
- avoid preallocating huge buffers and use a deque-based AudioBuffer
- reduce capture buffer from 10 hours to 60 seconds
- build fixes for non-Windows targets

## Testing
- `g++ -std=c++17 src/*.cpp -Iinclude -o lingo_test`
- `./lingo_test`

------
https://chatgpt.com/codex/tasks/task_e_688b252bbd64832a9b8adab76ef654c0