### PR TITLE
Optimize audio buffer storage

### DIFF
--- a/include/AudioBuffer.h
+++ b/include/AudioBuffer.h
@@ -2,7 +2,6 @@
 #define AUDIO_BUFFER_H
 
 #include <vector>
-#include <deque>
 #include <mutex>
 
 class AudioBuffer {
@@ -15,8 +14,10 @@ public:
 
 private:
     mutable std::mutex m_mutex;
-    std::deque<char> m_buffer;
+    std::vector<char> m_buffer;
     size_t m_capacity = 0;
+    size_t m_writePos = 0;
+    size_t m_size = 0;
 };
 
 #endif // AUDIO_BUFFER_H

--- a/src/AudioBuffer.cpp
+++ b/src/AudioBuffer.cpp
@@ -3,31 +3,39 @@
 #include <algorithm>
 
 AudioBuffer::AudioBuffer(size_t maxSamples)
-    : m_capacity(maxSamples) {}
+    : m_capacity(maxSamples), m_buffer(maxSamples) {}
 
 void AudioBuffer::setCapacity(size_t maxSamples) {
     std::lock_guard<std::mutex> lock(m_mutex);
-    m_buffer.clear();
+    m_buffer.assign(maxSamples, 0);
     m_capacity = maxSamples;
+    m_writePos = 0;
+    m_size = 0;
 }
 
 void AudioBuffer::push(const void* data, size_t bytes) {
     std::lock_guard<std::mutex> lock(m_mutex);
     const char* ptr = static_cast<const char*>(data);
+    if (m_capacity == 0) return;
     for (size_t i = 0; i < bytes; ++i) {
-        m_buffer.push_back(ptr[i]);
-    }
-    while (m_buffer.size() > m_capacity) {
-        m_buffer.pop_front();
+        m_buffer[m_writePos] = ptr[i];
+        m_writePos = (m_writePos + 1) % m_capacity;
+        if (m_size < m_capacity) ++m_size;
     }
 }
 
 std::vector<char> AudioBuffer::getLastSamples(double seconds, int bytesPerSecond) const {
     std::lock_guard<std::mutex> lock(m_mutex);
     size_t bytesNeeded = static_cast<size_t>(seconds * bytesPerSecond);
-    if (bytesNeeded > m_buffer.size()) bytesNeeded = m_buffer.size();
+    if (bytesNeeded > m_size) bytesNeeded = m_size;
     std::vector<char> out(bytesNeeded);
-    auto startIt = m_buffer.end() - bytesNeeded;
-    std::copy(startIt, m_buffer.end(), out.begin());
+    size_t startPos = (m_writePos + m_capacity - bytesNeeded) % m_capacity;
+    if (startPos + bytesNeeded <= m_capacity) {
+        std::copy_n(m_buffer.begin() + startPos, bytesNeeded, out.begin());
+    } else {
+        size_t firstPart = m_capacity - startPos;
+        std::copy_n(m_buffer.begin() + startPos, firstPart, out.begin());
+        std::copy_n(m_buffer.begin(), bytesNeeded - firstPart, out.begin() + firstPart);
+    }
     return out;
 }


### PR DESCRIPTION
## Summary
- rework `AudioBuffer` to use a circular `std::vector` instead of a `std::deque`
- add write position and size tracking for efficient memory usage

## Testing
- `g++ -std=c++17 -Iinclude -c src/AudioBuffer.cpp`
- `g++ -std=c++17 -Iinclude src/*.cpp -o live_lingo_example`
- `./live_lingo_example`

------
https://chatgpt.com/codex/tasks/task_e_688b27191488832aa693f2709a98bf0a