### PR TITLE
Add native whisper C++ integration

### DIFF
--- a/LiveLingo.vcxproj
+++ b/LiveLingo.vcxproj
@@ -135,7 +135,7 @@
     <ClInclude Include="include\SystemCapture.h" />
     <ClInclude Include="include\MicCapture.h" />
     <ClInclude Include="include\MuLaw.h" />
-    <ClInclude Include="include\PythonBridge.h" />
+    <ClInclude Include="include\WhisperBridge.h" />
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="src\AudioBuffer.cpp" />
@@ -143,7 +143,7 @@
     <ClCompile Include="src\AudioCapture.cpp" />
     <ClCompile Include="src\MuLaw.cpp" />
     <ClCompile Include="src\main.cpp" />
-    <ClCompile Include="src\PythonBridge.cpp" />
+    <ClCompile Include="src\WhisperBridge.cpp" />
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">

--- a/LiveLingo.vcxproj.filters
+++ b/LiveLingo.vcxproj.filters
@@ -30,7 +30,7 @@
     <ClCompile Include="src\main.cpp">
       <Filter>소스 파일</Filter>
     </ClCompile>
-    <ClCompile Include="src\PythonBridge.cpp">
+    <ClCompile Include="src\WhisperBridge.cpp">
       <Filter>소스 파일</Filter>
     </ClCompile>
   </ItemGroup>
@@ -53,7 +53,7 @@
     <ClInclude Include="include\MuLaw.h">
       <Filter>헤더 파일</Filter>
     </ClInclude>
-    <ClInclude Include="include\PythonBridge.h">
+    <ClInclude Include="include\WhisperBridge.h">
       <Filter>헤더 파일</Filter>
     </ClInclude>
   </ItemGroup>

--- a/include/WhisperBridge.h
+++ b/include/WhisperBridge.h
@@ -1,0 +1,11 @@
+#ifndef WHISPER_BRIDGE_H
+#define WHISPER_BRIDGE_H
+
+#include <string>
+
+namespace WhisperBridge {
+    // Transcribe the given WAV file using whisper.cpp
+    void transcribeFile(const std::string &modelPath, const std::string &wavPath);
+}
+
+#endif // WHISPER_BRIDGE_H

--- a/src/WhisperBridge.cpp
+++ b/src/WhisperBridge.cpp
@@ -1,0 +1,86 @@
+#include "WhisperBridge.h"
+#include "whisper.h"
+#include <fstream>
+#include <iostream>
+#include <vector>
+#include <cstring>
+#include <thread>
+
+namespace WhisperBridge {
+
+// Minimal WAV loader for 16-bit PCM mono
+static bool load_wav(const std::string &path, std::vector<float> &pcmf32, int &sampleRate) {
+    struct WavHeader {
+        char riff[4];
+        uint32_t chunkSize;
+        char wave[4];
+        char fmt[4];
+        uint32_t subchunk1Size;
+        uint16_t audioFormat;
+        uint16_t numChannels;
+        uint32_t sampleRate;
+        uint32_t byteRate;
+        uint16_t blockAlign;
+        uint16_t bitsPerSample;
+        char data[4];
+        uint32_t dataSize;
+    } header;
+
+    std::ifstream ifs(path, std::ios::binary);
+    if (!ifs) return false;
+    ifs.read(reinterpret_cast<char*>(&header), sizeof(header));
+    if (std::strncmp(header.riff, "RIFF", 4) != 0 || std::strncmp(header.wave, "WAVE", 4) != 0) {
+        return false;
+    }
+    sampleRate = header.sampleRate;
+    size_t numSamples = header.dataSize / (header.bitsPerSample / 8);
+    std::vector<int16_t> pcm16(numSamples);
+    ifs.read(reinterpret_cast<char*>(pcm16.data()), header.dataSize);
+    pcmf32.resize(numSamples);
+    for (size_t i = 0; i < numSamples; ++i) {
+        pcmf32[i] = pcm16[i] / 32768.0f;
+    }
+    return true;
+}
+
+void transcribeFile(const std::string &modelPath, const std::string &wavPath) {
+    std::vector<float> pcmf32;
+    int sampleRate = 0;
+    if (!load_wav(wavPath, pcmf32, sampleRate)) {
+        std::cerr << "Failed to load WAV file: " << wavPath << std::endl;
+        return;
+    }
+    if (sampleRate != WHISPER_SAMPLE_RATE) {
+        std::cerr << "Unsupported sample rate" << std::endl;
+        return;
+    }
+
+    struct whisper_context * ctx = whisper_init_from_file(modelPath.c_str());
+    if (!ctx) {
+        std::cerr << "Failed to load model: " << modelPath << std::endl;
+        return;
+    }
+
+    whisper_full_params params = whisper_full_default_params(WHISPER_SAMPLING_GREEDY);
+    params.print_progress   = false;
+    params.print_realtime   = false;
+    params.print_timestamps = false;
+    params.language         = "ko";
+    params.n_threads        = std::max(1u, std::thread::hardware_concurrency());
+
+    if (whisper_full(ctx, params, pcmf32.data(), pcmf32.size()) != 0) {
+        std::cerr << "whisper_full() failed" << std::endl;
+        whisper_free(ctx);
+        return;
+    }
+
+    int n = whisper_full_n_segments(ctx);
+    for (int i = 0; i < n; ++i) {
+        const char * text = whisper_full_get_segment_text(ctx, i);
+        std::cout << text << std::endl;
+    }
+
+    whisper_free(ctx);
+}
+
+} // namespace WhisperBridge

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -2,17 +2,13 @@
 #include "MicCapture.h"
 #include "WavWriter.h"
 #include <iostream>
-#include "PythonBridge.h"
+#include "WhisperBridge.h"
 #include <thread>
 #ifdef _WIN32
 #include <conio.h>
 #endif
 
 int main() {
-#ifdef _WIN32
-    std::thread pyThread([](){ PythonBridge::runTranscription(); });
-    pyThread.detach();
-#endif
 #ifdef _WIN32
     SystemCapture systemCap;
     MicCapture micCap;
@@ -40,6 +36,7 @@ int main() {
             WavWriter::writeWav("system.wav", sysData, sysRate, sysChannels, sysBits, sysFormat);
             WavWriter::writeWav("mic.wav", micData, micRate, micChannels, micBits, micFormat);
             std::cout << "Saved" << std::endl;
+            WhisperBridge::transcribeFile("models/ggml-base.bin", "mic.wav");
         }
     }
     systemCap.stop();


### PR DESCRIPTION
## Summary
- add `WhisperBridge` C++ wrapper using whisper.cpp
- call `WhisperBridge` in `main` instead of Python
- include new files in Visual Studio project

## Testing
- `python3 -m py_compile realtime_transcribe.py`
- `g++ -std=c++17 -Iinclude -c src/main.cpp -o /tmp/main.o`
- `g++ -std=c++17 -Iinclude -I/tmp/whispercpp/include -I/tmp/whispercpp/ggml/include -c src/WhisperBridge.cpp -o /tmp/WhisperBridge.o`

------
https://chatgpt.com/codex/tasks/task_e_688b3f0ae158832aaa2ffcf6afec3a3d