### PR TITLE
Fix whisper deprecation warning

### DIFF
--- a/src/WhisperBridge.cpp
+++ b/src/WhisperBridge.cpp
@@ -55,7 +55,8 @@ void transcribeFile(const std::string &modelPath, const std::string &wavPath) {
         return;
     }
 
-    struct whisper_context * ctx = whisper_init_from_file(modelPath.c_str());
+    whisper_context_params cparams = whisper_context_default_params();
+    struct whisper_context * ctx = whisper_init_from_file_with_params(modelPath.c_str(), cparams);
     if (!ctx) {
         std::cerr << "Failed to load model: " << modelPath << std::endl;
         return;


### PR DESCRIPTION
## Summary
- update WhisperBridge to use `whisper_init_from_file_with_params`

## Testing
- `python3 -m py_compile realtime_transcribe.py`


------
https://chatgpt.com/codex/tasks/task_e_688c0d0ff2bc832a9c017979e7bd2623