### PR TITLE
Improve Unicode output and optional language setting

### DIFF
--- a/include/WhisperBridge.h
+++ b/include/WhisperBridge.h
@@ -4,8 +4,12 @@
 #include <string>
 
 namespace WhisperBridge {
-    // Transcribe the given WAV file using whisper.cpp
-    void transcribeFile(const std::string &modelPath, const std::string &wavPath);
+    // Transcribe the given WAV file using whisper.cpp. Language can be
+    // specified (e.g. "en" or "ko"). If empty, whisper.cpp will try to
+    // detect the language automatically.
+    void transcribeFile(const std::string &modelPath,
+                        const std::string &wavPath,
+                        const std::string &language = "");
 }
 
 #endif // WHISPER_BRIDGE_H

--- a/src/WhisperBridge.cpp
+++ b/src/WhisperBridge.cpp
@@ -87,7 +87,9 @@ static bool load_wav(const std::string &path, std::vector<float> &pcmf32, int &s
     return true;
 }
 
-void transcribeFile(const std::string &modelPath, const std::string &wavPath) {
+void transcribeFile(const std::string &modelPath,
+                    const std::string &wavPath,
+                    const std::string &language) {
     std::vector<float> pcmf32;
     int sampleRate = 0;
     if (!load_wav(wavPath, pcmf32, sampleRate)) {
@@ -111,7 +113,13 @@ void transcribeFile(const std::string &modelPath, const std::string &wavPath) {
     params.print_progress   = false;
     params.print_realtime   = false;
     params.print_timestamps = false;
-    params.language         = "ko";
+    if (!language.empty()) {
+        params.language = language.c_str();
+        params.detect_language = false;
+    } else {
+        params.language = "";
+        params.detect_language = true;
+    }
     params.n_threads        = std::max(1u, std::thread::hardware_concurrency());
 
     if (whisper_full(ctx, params, pcmf32.data(), pcmf32.size()) != 0) {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -6,10 +6,15 @@
 #include <thread>
 #ifdef _WIN32
 #include <conio.h>
+#include <windows.h>
+#include <locale>
 #endif
 
 int main() {
 #ifdef _WIN32
+    SetConsoleOutputCP(CP_UTF8);
+    SetConsoleCP(CP_UTF8);
+    std::setlocale(LC_ALL, ".65001");
     SystemCapture systemCap;
     MicCapture micCap;
     if (!systemCap.start() || !micCap.start()) {
@@ -27,6 +32,7 @@ int main() {
     const short micChannels = micCap.channels();
     const short micBits = micCap.bitsPerSample();
     const short micFormat = micCap.formatType();
+    const std::string language = ""; // empty -> auto-detect, e.g. "en" or "ko"
     while (true) {
         int ch = _getch();
         if (ch == 'q') break;
@@ -36,7 +42,7 @@ int main() {
             WavWriter::writeWav("system.wav", sysData, sysRate, sysChannels, sysBits, sysFormat);
             WavWriter::writeWav("mic.wav", micData, micRate, micChannels, micBits, micFormat);
             std::cout << "Saved" << std::endl;
-            WhisperBridge::transcribeFile("models/ggml-base.bin", "mic.wav");
+            WhisperBridge::transcribeFile("models/ggml-base.bin", "mic.wav", language);
         }
     }
     systemCap.stop();


### PR DESCRIPTION
## Summary
- fix console encoding on Windows with UTF-8 code page
- allow language detection/selection in WhisperBridge

## Testing
- `python3 -m py_compile realtime_transcribe.py`
- `g++ -std=c++17 -c src/main.cpp -Iinclude`
- `g++ -std=c++17 -c src/WhisperBridge.cpp -Iinclude` *(fails: `whisper.h` not found)*

------
https://chatgpt.com/codex/tasks/task_e_688c6f18d454832aa7dbff7c8b8c4c40