### PR TITLE
Support streaming transcription with persistent Whisper model

### DIFF
--- a/include/WhisperBridge.h
+++ b/include/WhisperBridge.h
@@ -2,6 +2,7 @@
 #define WHISPER_BRIDGE_H
 
 #include <string>
+#include <vector>
 
 namespace WhisperBridge {
     // Transcribe the given WAV file using whisper.cpp. Language can be
@@ -10,6 +11,28 @@ namespace WhisperBridge {
     void transcribeFile(const std::string &modelPath,
                         const std::string &wavPath,
                         const std::string &language = "");
+
+    // Helper class that keeps a whisper.cpp context alive and allows
+    // repeatedly transcribing raw PCM data without reloading the model.
+    class WhisperStream {
+    public:
+        WhisperStream(const std::string &modelPath,
+                      const std::string &language = "");
+        ~WhisperStream();
+
+        // Transcribe raw PCM audio. The buffer can contain 16-bit PCM or
+        // 32-bit float samples with an arbitrary channel count. The audio is
+        // converted to mono and resampled to WHISPER_SAMPLE_RATE internally.
+        std::string transcribe(const std::vector<char> &pcm,
+                               int sampleRate,
+                               int channels,
+                               int bitsPerSample,
+                               int formatType);
+
+    private:
+        struct whisper_context* m_ctx = nullptr;
+        std::string m_language;
+    };
 }
 
 #endif // WHISPER_BRIDGE_H

--- a/src/WhisperBridge.cpp
+++ b/src/WhisperBridge.cpp
@@ -5,6 +5,8 @@
 #include <vector>
 #include <cstring>
 #include <thread>
+#include <cmath>
+#include <algorithm>
 
 namespace WhisperBridge {
 
@@ -87,6 +89,56 @@ static bool load_wav(const std::string &path, std::vector<float> &pcmf32, int &s
     return true;
 }
 
+// Convert arbitrary PCM data to mono float32 and resample to
+// WHISPER_SAMPLE_RATE. Supports 16-bit PCM and 32-bit float input.
+static bool convert_pcm(const std::vector<char> &pcm,
+                        int sampleRate,
+                        int channels,
+                        int bitsPerSample,
+                        int formatType,
+                        std::vector<float> &pcmf32) {
+    const size_t bytesPerSample = bitsPerSample / 8;
+    if (bytesPerSample == 0 || channels <= 0) return false;
+    const size_t frameCount = pcm.size() / (bytesPerSample * channels);
+    std::vector<float> tmp(frameCount * channels);
+    if (formatType == 1 && bitsPerSample == 16) {
+        const int16_t* data = reinterpret_cast<const int16_t*>(pcm.data());
+        for (size_t i = 0; i < frameCount * channels; ++i) {
+            tmp[i] = static_cast<float>(data[i]) / 32768.0f;
+        }
+    } else if (formatType == 3 && bitsPerSample == 32) {
+        const float* data = reinterpret_cast<const float*>(pcm.data());
+        std::copy(data, data + frameCount * channels, tmp.begin());
+    } else {
+        return false;
+    }
+
+    pcmf32.resize(frameCount);
+    for (size_t i = 0; i < frameCount; ++i) {
+        float sum = 0.0f;
+        for (int c = 0; c < channels; ++c) {
+            sum += tmp[i * channels + c];
+        }
+        pcmf32[i] = sum / channels;
+    }
+
+    if (sampleRate != WHISPER_SAMPLE_RATE && sampleRate > 0) {
+        const size_t newFrameCount =
+            static_cast<size_t>((static_cast<uint64_t>(frameCount) * WHISPER_SAMPLE_RATE) / sampleRate);
+        std::vector<float> resampled(newFrameCount);
+        for (size_t i = 0; i < newFrameCount; ++i) {
+            float pos = static_cast<float>(i) * sampleRate / WHISPER_SAMPLE_RATE;
+            size_t idx = static_cast<size_t>(pos);
+            float frac = pos - idx;
+            float v1 = idx < frameCount ? pcmf32[idx] : 0.0f;
+            float v2 = (idx + 1 < frameCount) ? pcmf32[idx + 1] : v1;
+            resampled[i] = v1 + (v2 - v1) * frac;
+        }
+        pcmf32.swap(resampled);
+    }
+    return true;
+}
+
 void transcribeFile(const std::string &modelPath,
                     const std::string &wavPath,
                     const std::string &language) {
@@ -137,6 +189,61 @@ void transcribeFile(const std::string &modelPath,
     }
 
     whisper_free(ctx);
+}
+
+WhisperStream::WhisperStream(const std::string &modelPath,
+                             const std::string &language)
+    : m_language(language) {
+    whisper_context_params cparams = whisper_context_default_params();
+    cparams.use_gpu = true;
+    m_ctx = whisper_init_from_file_with_params(modelPath.c_str(), cparams);
+    if (!m_ctx) {
+        std::cerr << "Failed to load model: " << modelPath << std::endl;
+    }
+}
+
+WhisperStream::~WhisperStream() {
+    if (m_ctx) {
+        whisper_free(m_ctx);
+    }
+}
+
+std::string WhisperStream::transcribe(const std::vector<char> &pcm,
+                                      int sampleRate,
+                                      int channels,
+                                      int bitsPerSample,
+                                      int formatType) {
+    if (!m_ctx) return {};
+    std::vector<float> pcmf32;
+    if (!convert_pcm(pcm, sampleRate, channels, bitsPerSample, formatType, pcmf32)) {
+        return {};
+    }
+    whisper_full_params params = whisper_full_default_params(WHISPER_SAMPLING_GREEDY);
+    params.print_progress   = false;
+    params.print_realtime   = false;
+    params.print_timestamps = false;
+    if (!m_language.empty()) {
+        params.language = m_language.c_str();
+        params.detect_language = false;
+    } else {
+        params.language = "";
+        params.detect_language = true;
+    }
+    params.n_threads        = std::max(1u, std::thread::hardware_concurrency());
+
+    if (whisper_full(m_ctx, params, pcmf32.data(), pcmf32.size()) != 0) {
+        std::cerr << "whisper_full() failed" << std::endl;
+        return {};
+    }
+
+    std::string text;
+    int n = whisper_full_n_segments(m_ctx);
+    for (int i = 0; i < n; ++i) {
+        const char * seg = whisper_full_get_segment_text(m_ctx, i);
+        text += seg;
+    }
+    whisper_reset_state(m_ctx);
+    return text;
 }
 
 } // namespace WhisperBridge


### PR DESCRIPTION
## Summary
- add `WhisperStream` class that keeps a whisper.cpp context alive
- convert raw PCM chunks and transcribe without saving to files
- stream microphone audio in `main.cpp` and print text continuously

## Testing
- `g++ -std=c++17 -Iinclude src/main.cpp src/WhisperBridge.cpp src/AudioCapture.cpp src/AudioBuffer.cpp src/MicCapture.cpp src/SystemCapture.cpp src/WavWriter.cpp src/MuLaw.cpp src/PythonBridge.cpp -o test` (fails: whisper.h missing)
- `python -m py_compile realtime_transcribe.py`


------
https://chatgpt.com/codex/tasks/task_e_688e485c80e8832abafb610efed372f0