### PR TITLE
Fix console encoding for Korean output

### DIFF
--- a/LiveLingo.vcxproj
+++ b/LiveLingo.vcxproj
@@ -110,6 +110,7 @@
       <SDLCheck>true</SDLCheck>
       <PreprocessorDefinitions>_DEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
+      <AdditionalOptions>/utf-8 %(AdditionalOptions)</AdditionalOptions>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
@@ -125,6 +126,7 @@
       <SDLCheck>true</SDLCheck>
       <PreprocessorDefinitions>NDEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
+      <AdditionalOptions>/utf-8 %(AdditionalOptions)</AdditionalOptions>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -15,9 +15,14 @@
 #pragma comment(lib, "ggml-base.lib")
 #pragma comment(lib, "ggml-cuda.lib")
 
-#pragma comment(lib, "cudart.lib")      // cudaDeviceSynchronize, cudaGetLastError ¡¦
-#pragma comment(lib, "cuda.lib")        // cuDeviceGet, cuGetErrorString ¡¦
-#pragma comment(lib, "cublas.lib")      // cublasCreate_v2, cublasDestroy_v2 ¡¦
+#include <clocale>
+#ifdef _WIN32
+#include <windows.h>
+#endif
+
+#pragma comment(lib, "cudart.lib")      // cudaDeviceSynchronize, cudaGetLastError Â¡Â¦
+#pragma comment(lib, "cuda.lib")        // cuDeviceGet, cuGetErrorString Â¡Â¦
+#pragma comment(lib, "cublas.lib")      // cublasCreate_v2, cublasDestroy_v2 Â¡Â¦
 
 
 #include "common-sdl.h"
@@ -135,6 +140,11 @@ void whisper_print_usage(int /*argc*/, char ** argv, const whisper_params & para
 }
 
 int main(int argc, char ** argv) {
+    std::setlocale(LC_ALL, "");
+#ifdef _WIN32
+    SetConsoleOutputCP(CP_UTF8);
+    SetConsoleCP(CP_UTF8);
+#endif
     ggml_backend_load_all();
 
     whisper_params params;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -15,8 +15,8 @@
 #pragma comment(lib, "ggml-base.lib")
 #pragma comment(lib, "ggml-cuda.lib")
 
-#include <clocale>
 #ifdef _WIN32
+#define NOMINMAX        // <-- 반드시 windows.h보다 먼저 선언
 #include <windows.h>
 #endif
 
@@ -140,7 +140,7 @@ void whisper_print_usage(int /*argc*/, char ** argv, const whisper_params & para
 }
 
 int main(int argc, char ** argv) {
-    std::setlocale(LC_ALL, "");
+    std::setlocale(LC_ALL, ".65001");
 #ifdef _WIN32
     SetConsoleOutputCP(CP_UTF8);
     SetConsoleCP(CP_UTF8);


### PR DESCRIPTION
## Summary
- Configure Windows console to use UTF-8 so Korean text displays correctly
- Initialize global locale for wide-character support

## Testing
- `g++ -std=c++17 -Isrc -Iinclude -c src/main.cpp` *(fails: SDL.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_688f037c8418832ab57a822ec1ff9705