### PR TITLE
feat: add timestamped printing

### DIFF
--- a/include/common.h
+++ b/include/common.h
@@ -11,6 +11,8 @@
 #include <fstream>
 #include <sstream>
 
+void timestamped_print(const char *fmt, ...);
+
 //
 // GPT CLI argument parsing
 //

--- a/src/common.cpp
+++ b/src/common.cpp
@@ -9,6 +9,29 @@
 #include <locale>
 #include <regex>
 #include <sstream>
+#include <chrono>
+#include <cstdarg>
+#include <cstdio>
+
+void timestamped_print(const char *fmt, ...) {
+    using namespace std::chrono;
+    auto now = system_clock::now();
+    std::time_t t = system_clock::to_time_t(now);
+    std::tm tm_info;
+#ifdef _WIN32
+    localtime_s(&tm_info, &t);
+#else
+    localtime_r(&t, &tm_info);
+#endif
+    char buf[20];
+    std::strftime(buf, sizeof(buf), "%Y-%m-%d %H:%M:%S", &tm_info);
+    std::fprintf(stdout, "[%s] ", buf);
+    va_list args;
+    va_start(args, fmt);
+    std::vfprintf(stdout, fmt, args);
+    va_end(args);
+    std::fflush(stdout);
+}
 
 // Function to check if the next argument exists
 static std::string get_next_arg(int& i, int argc, char** argv, const std::string& flag, gpt_params& params) {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -365,8 +365,7 @@ int main(int argc, char ** argv) {
                 const char * text = whisper_full_get_segment_text(ctx, i);
 
                 if (params.no_timestamps) {
-                    printf("%s", text);
-                    fflush(stdout);
+                    timestamped_print("%s", text);
 
                     if (params.fname_out.length() > 0) {
                         fout << text;
@@ -377,8 +376,7 @@ int main(int argc, char ** argv) {
 
                     std::string output = "[" + to_timestamp(t0, false) + " --> " + to_timestamp(t1, false) + "]  " + text;
 
-                    printf("%s", output.c_str());
-                    fflush(stdout);
+                    timestamped_print("%s", output.c_str());
 
                     if (params.fname_out.length() > 0) {
                         fout << output;
@@ -409,8 +407,7 @@ int main(int argc, char ** argv) {
         }
     });
 
-    printf("[Start speaking]\n");
-    fflush(stdout);
+    timestamped_print("[Start speaking]\n");
 
     // main audio loop
     while (is_running.load()) {


### PR DESCRIPTION
## Summary
- add helper to print timestamps before each message
- use timestamped output for transcription text and start prompt

## Testing
- `g++ -std=c++17 -c src/common.cpp -Iinclude`
- `g++ -std=c++17 -c src/main.cpp -Iinclude -Isrc -I/usr/include/SDL2`


------
https://chatgpt.com/codex/tasks/task_e_688f3970cc44832a94ef21d41da4ea9f