### PR TITLE
feat: add option to transcribe with OpenAI API

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@
 *.userosscache
 *.sln.docstates
 *.env
+.env
 
 # User-specific files (MonoDevelop/Xamarin Studio)
 *.userprefs

--- a/LiveLingo.vcxproj
+++ b/LiveLingo.vcxproj
@@ -146,6 +146,7 @@
     <ClInclude Include="include\ggml.h" />
     <ClInclude Include="include\whisper.h" />
     <ClInclude Include="include\vad.h" />
+    <ClInclude Include="include\openai_client.h" />
     <ClInclude Include="src\miniaudio.h" />
     <None Include="src\stb_vorbis.c" />
   </ItemGroup>
@@ -155,6 +156,7 @@
     <ClCompile Include="src\common.cpp" />
     <ClCompile Include="src\system-audio.cpp" />
     <ClCompile Include="src\main.cpp" />
+    <ClCompile Include="src\openai_client.cpp" />
     <ClCompile Include="src\vad.cpp" />
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />

--- a/LiveLingo.vcxproj.filters
+++ b/LiveLingo.vcxproj.filters
@@ -26,6 +26,9 @@
     <ClCompile Include="src\main.cpp">
       <Filter>소스 파일</Filter>
     </ClCompile>
+    <ClCompile Include="src\openai_client.cpp">
+      <Filter>소스 파일</Filter>
+    </ClCompile>
     <ClCompile Include="src\vad.cpp">
       <Filter>소스 파일</Filter>
     </ClCompile>
@@ -62,6 +65,9 @@
       <Filter>헤더 파일</Filter>
     </ClInclude>
     <ClInclude Include="include\vad.h">
+      <Filter>헤더 파일</Filter>
+    </ClInclude>
+    <ClInclude Include="include\openai_client.h">
       <Filter>헤더 파일</Filter>
     </ClInclude>
     <ClInclude Include="src\miniaudio.h">

--- a/include/openai_client.h
+++ b/include/openai_client.h
@@ -1,0 +1,9 @@
+#pragma once
+
+#include <string>
+#include <vector>
+
+// Transcribe audio using OpenAI's API.
+// The audio vector is expected to contain PCM samples at WHISPER_SAMPLE_RATE.
+std::string openai_transcribe(const std::vector<float> &audio, const std::string &language);
+

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -34,6 +34,7 @@
 #include "whisper.h"
 #include "ggml-backend.h"
 #include "vad.h"
+#include "openai_client.h"
 
 #include <chrono>
 #include <cstdio>
@@ -111,6 +112,7 @@ struct whisper_params {
     bool use_gpu       = false;
 #endif
     bool flash_attn    = true;
+    bool use_openai    = false;
 
     std::string language  = "ko";
 
@@ -245,6 +247,11 @@ int main(int argc, char ** argv) {
 
     audio->resume();
 
+    std::cout << "Select inference engine (0: local model, 1: OpenAI API): ";
+    int engine_choice = 0;
+    std::cin >> engine_choice;
+    params.use_openai = (engine_choice == 1);
+
     // whisper init
     if (params.language != "auto" && whisper_lang_id(params.language.c_str()) == -1){
         fprintf(stderr, "error: unknown language '%s'\n", params.language.c_str());
@@ -257,10 +264,13 @@ int main(int argc, char ** argv) {
     cparams.use_gpu    = params.use_gpu;
     cparams.flash_attn = params.flash_attn;
 
-    struct whisper_context * ctx = whisper_init_from_file_with_params(params.model.c_str(), cparams);
-    if (ctx == nullptr) {
-        fprintf(stderr, "error: failed to initialize whisper context\n");
-        return 2;
+    struct whisper_context * ctx = nullptr;
+    if (!params.use_openai) {
+        ctx = whisper_init_from_file_with_params(params.model.c_str(), cparams);
+        if (ctx == nullptr) {
+            fprintf(stderr, "error: failed to initialize whisper context\n");
+            return 2;
+        }
     }
 
     std::vector<float> pcmf32_new(n_samples_30s, 0.0f);
@@ -270,7 +280,7 @@ int main(int argc, char ** argv) {
     // print some info about the processing
     {
         fprintf(stderr, "\n");
-        if (!whisper_is_multilingual(ctx)) {
+        if (!params.use_openai && ctx && !whisper_is_multilingual(ctx)) {
             if (params.language != "en" || params.translate) {
                 params.language = "en";
                 params.translate = false;
@@ -372,50 +382,58 @@ int main(int argc, char ** argv) {
             memcpy(pcmf32.data() + n_samples_take, pcmf32_new_local.data(), n_samples_new*sizeof(float));
             pcmf32_old = pcmf32;
 
-            whisper_full_params wparams = whisper_full_default_params(params.beam_size > 1 ? WHISPER_SAMPLING_BEAM_SEARCH : WHISPER_SAMPLING_GREEDY);
-            wparams.print_progress   = false;
-            wparams.print_special    = params.print_special;
-            wparams.print_realtime   = false;
-            wparams.print_timestamps = !params.no_timestamps;
-            wparams.translate        = params.translate;
-            wparams.single_segment   = !use_vad;
-            wparams.max_tokens       = params.max_tokens;
-            wparams.language         = params.language.c_str();
-            wparams.n_threads        = params.n_threads;
-            wparams.beam_search.beam_size = params.beam_size;
-            wparams.audio_ctx        = params.audio_ctx;
-            wparams.tdrz_enable      = params.tinydiarize;
-            wparams.temperature_inc  = params.no_fallback ? 0.0f : wparams.temperature_inc;
-            wparams.prompt_tokens    = params.no_context ? nullptr : prompt_tokens.data();
-            wparams.prompt_n_tokens  = params.no_context ? 0       : prompt_tokens.size();
-
-            if (whisper_full(ctx, wparams, pcmf32.data(), pcmf32.size()) != 0) {
-                fprintf(stderr, "%s: failed to process audio\n", argv[0]);
-                is_running.store(false);
-                break;
-            }
-
-            if (!use_vad) {
-                printf("\33[2K\r");
-                printf("%s", std::string(100, ' ').c_str());
-                printf("\33[2K\r");
-            }
-            const int n_segments = whisper_full_n_segments(ctx);
-            for (int i = 0; i < n_segments; ++i) {
-                const char * text = whisper_full_get_segment_text(ctx, i);
-
-                if (params.no_timestamps) {
-                    timestamped_print("%s", text);
-                } else {
-                    const int64_t t0 = whisper_full_get_segment_t0(ctx, i);
-                    const int64_t t1 = whisper_full_get_segment_t1(ctx, i);
-
-                    std::string output = "[" + to_timestamp(t0, false) + " --> " + to_timestamp(t1, false) + "]  " + text;
-
-                    timestamped_print("%s", output.c_str());
+            if (params.use_openai) {
+                std::string text = openai_transcribe(pcmf32, params.language);
+                if (!text.empty()) {
+                    timestamped_print("%s", text.c_str());
+                    sentence = text;
                 }
-                sentence = text;
-                //sentence += " ";
+            } else {
+                whisper_full_params wparams = whisper_full_default_params(params.beam_size > 1 ? WHISPER_SAMPLING_BEAM_SEARCH : WHISPER_SAMPLING_GREEDY);
+                wparams.print_progress   = false;
+                wparams.print_special    = params.print_special;
+                wparams.print_realtime   = false;
+                wparams.print_timestamps = !params.no_timestamps;
+                wparams.translate        = params.translate;
+                wparams.single_segment   = !use_vad;
+                wparams.max_tokens       = params.max_tokens;
+                wparams.language         = params.language.c_str();
+                wparams.n_threads        = params.n_threads;
+                wparams.beam_search.beam_size = params.beam_size;
+                wparams.audio_ctx        = params.audio_ctx;
+                wparams.tdrz_enable      = params.tinydiarize;
+                wparams.temperature_inc  = params.no_fallback ? 0.0f : wparams.temperature_inc;
+                wparams.prompt_tokens    = params.no_context ? nullptr : prompt_tokens.data();
+                wparams.prompt_n_tokens  = params.no_context ? 0       : prompt_tokens.size();
+
+                if (whisper_full(ctx, wparams, pcmf32.data(), pcmf32.size()) != 0) {
+                    fprintf(stderr, "%s: failed to process audio\n", argv[0]);
+                    is_running.store(false);
+                    break;
+                }
+
+                if (!use_vad) {
+                    printf("\33[2K\r");
+                    printf("%s", std::string(100, ' ').c_str());
+                    printf("\33[2K\r");
+                }
+                const int n_segments = whisper_full_n_segments(ctx);
+                for (int i = 0; i < n_segments; ++i) {
+                    const char * text = whisper_full_get_segment_text(ctx, i);
+
+                    if (params.no_timestamps) {
+                        timestamped_print("%s", text);
+                    } else {
+                        const int64_t t0 = whisper_full_get_segment_t0(ctx, i);
+                        const int64_t t1 = whisper_full_get_segment_t1(ctx, i);
+
+                        std::string output = "[" + to_timestamp(t0, false) + " --> " + to_timestamp(t1, false) + "]  " + text;
+
+                        timestamped_print("%s", output.c_str());
+                    }
+                    sentence = text;
+                    //sentence += " ";
+                }
             }
 
             ++n_iter;
@@ -429,7 +447,7 @@ int main(int argc, char ** argv) {
                 }
                 sentence.clear();
                 pcmf32_old = std::vector<float>(pcmf32.end() - n_samples_keep, pcmf32.end());
-                if (!params.no_context) {
+                if (!params.use_openai && !params.no_context) {
                     prompt_tokens.clear();
                     const int n_segments = whisper_full_n_segments(ctx);
                     for (int i = 0; i < n_segments; ++i) {
@@ -513,8 +531,10 @@ int main(int argc, char ** argv) {
 
     audio->pause();
 
-    whisper_print_timings(ctx);
-    whisper_free(ctx);
+    if (ctx) {
+        whisper_print_timings(ctx);
+        whisper_free(ctx);
+    }
 
     return 0;
 }

--- a/src/openai_client.cpp
+++ b/src/openai_client.cpp
@@ -1,0 +1,103 @@
+#include "openai_client.h"
+#include "common.h"
+#include "whisper.h"
+
+#include <curl/curl.h>
+#include <cstdlib>
+#include <fstream>
+#include <sstream>
+
+// simple helper to read environment variable or fallback to .env file
+static std::string get_env(const std::string &key) {
+    const char *val = std::getenv(key.c_str());
+    if (val) {
+        return std::string(val);
+    }
+    std::ifstream env(".env");
+    std::string line;
+    while (std::getline(env, line)) {
+        if (line.empty() || line[0] == '#') continue;
+        size_t pos = line.find('=');
+        if (pos == std::string::npos) continue;
+        std::string k = line.substr(0, pos);
+        std::string v = line.substr(pos + 1);
+        if (k == key) {
+            return v;
+        }
+    }
+    return "";
+}
+
+static size_t write_callback(void *contents, size_t size, size_t nmemb, void *userp) {
+    size_t total = size * nmemb;
+    static_cast<std::string*>(userp)->append(static_cast<char*>(contents), total);
+    return total;
+}
+
+std::string openai_transcribe(const std::vector<float> &audio, const std::string &language) {
+    std::string api_key = get_env("OPENAI_API_KEY");
+    if (api_key.empty()) {
+        fprintf(stderr, "OPENAI_API_KEY is not set\n");
+        return "";
+    }
+
+    // Save audio to temporary wav file
+    const std::string tmp_file = "openai_tmp.wav";
+    wav_writer writer;
+    writer.open(tmp_file, WHISPER_SAMPLE_RATE, 16, 1);
+    writer.write(audio.data(), audio.size());
+    writer.close();
+
+    CURL *curl = curl_easy_init();
+    if (!curl) {
+        return "";
+    }
+
+    struct curl_httppost *form = nullptr;
+    struct curl_httppost *last = nullptr;
+
+    curl_formadd(&form, &last,
+                 CURLFORM_COPYNAME, "model",
+                 CURLFORM_COPYCONTENTS, "gpt-4o-mini-transcribe",
+                 CURLFORM_END);
+
+    curl_formadd(&form, &last,
+                 CURLFORM_COPYNAME, "file",
+                 CURLFORM_FILE, tmp_file.c_str(),
+                 CURLFORM_END);
+
+    curl_formadd(&form, &last,
+                 CURLFORM_COPYNAME, "response_format",
+                 CURLFORM_COPYCONTENTS, "text",
+                 CURLFORM_END);
+
+    curl_formadd(&form, &last,
+                 CURLFORM_COPYNAME, "language",
+                 CURLFORM_COPYCONTENTS, language.c_str(),
+                 CURLFORM_END);
+
+    std::string response;
+    struct curl_slist *headers = nullptr;
+    std::string auth = "Authorization: Bearer " + api_key;
+    headers = curl_slist_append(headers, auth.c_str());
+
+    curl_easy_setopt(curl, CURLOPT_URL, "https://api.openai.com/v1/audio/transcriptions");
+    curl_easy_setopt(curl, CURLOPT_HTTPHEADER, headers);
+    curl_easy_setopt(curl, CURLOPT_HTTPPOST, form);
+    curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, write_callback);
+    curl_easy_setopt(curl, CURLOPT_WRITEDATA, &response);
+
+    CURLcode res = curl_easy_perform(curl);
+
+    curl_easy_cleanup(curl);
+    curl_formfree(form);
+    curl_slist_free_all(headers);
+
+    if (res != CURLE_OK) {
+        fprintf(stderr, "OpenAI request failed: %s\n", curl_easy_strerror(res));
+        return "";
+    }
+
+    return response;
+}
+


### PR DESCRIPTION
## Summary
- allow choosing between local Whisper model and OpenAI API at runtime
- load OpenAI API key from `.env` and send audio to `gpt-4o-mini-transcribe`
- ignore `.env` so keys are not committed
- guard Whisper-only code paths to avoid null pointer when using the OpenAI API

## Testing
- `g++ -std=c++17 -Iinclude -c src/openai_client.cpp`
- `g++ -std=c++17 -Iinclude -c src/main.cpp` *(fails: SDL.h: No such file or directory)*


------
https://chatgpt.com/codex/tasks/task_e_689014689c70832abe80b5ef946911db