### PR TITLE
feat: add OpenAI realtime transcription via WebSocket

### DIFF
--- a/include/openai_client.h
+++ b/include/openai_client.h
@@ -2,8 +2,30 @@
 
 #include <string>
 #include <vector>
+#include <curl/curl.h>
 
 // Transcribe audio using OpenAI's API.
 // The audio vector is expected to contain PCM samples at WHISPER_SAMPLE_RATE.
 std::string openai_transcribe(const std::vector<float> &audio, const std::string &language);
+
+// Simple WebSocket client for the OpenAI realtime transcription API
+class OpenAIRealtimeClient {
+public:
+    explicit OpenAIRealtimeClient(const std::string &language);
+    ~OpenAIRealtimeClient();
+
+    // establish websocket connection and send the initial config message
+    bool connect();
+
+    // send a chunk of PCM audio (float samples in [-1,1])
+    bool send_audio(const std::vector<float> &audio);
+
+    // receive a transcript message, returns false if no message available
+    bool receive_transcript(std::string &text);
+
+private:
+    std::string m_language;
+    CURL *m_curl = nullptr;
+    struct curl_slist *m_headers = nullptr;
+};
 

--- a/src/openai_client.cpp
+++ b/src/openai_client.cpp
@@ -7,6 +7,9 @@
 #include <cstdlib>
 #include <fstream>
 #include <sstream>
+#include <algorithm>
+#include <chrono>
+#include <thread>
 
 // simple helper to read environment variable or fallback to .env file
 static std::string get_env(const std::string &key) {
@@ -33,6 +36,37 @@ static size_t write_callback(void *contents, size_t size, size_t nmemb, void *us
     size_t total = size * nmemb;
     static_cast<std::string*>(userp)->append(static_cast<char*>(contents), total);
     return total;
+}
+
+// basic base64 encoder
+static std::string base64_encode(const unsigned char *data, size_t len) {
+    static const char table[] = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
+    std::string out;
+    out.reserve(((len + 2) / 3) * 4);
+    int val = 0;
+    int valb = -6;
+    for (size_t i = 0; i < len; ++i) {
+        unsigned char c = data[i];
+        val = (val << 8) + c;
+        valb += 8;
+        while (valb >= 0) {
+            out.push_back(table[(val >> valb) & 0x3F]);
+            valb -= 6;
+        }
+    }
+    if (valb > -6) out.push_back(table[((val << 8) >> (valb + 8)) & 0x3F]);
+    while (out.size() % 4) out.push_back('=');
+    return out;
+}
+
+static std::string pcmf32_to_base64(const std::vector<float> &audio) {
+    std::vector<int16_t> pcm16(audio.size());
+    for (size_t i = 0; i < audio.size(); ++i) {
+        float v = std::max(-1.0f, std::min(1.0f, audio[i]));
+        pcm16[i] = (int16_t) (v * 32767.0f);
+    }
+    const unsigned char *bytes = reinterpret_cast<const unsigned char*>(pcm16.data());
+    return base64_encode(bytes, pcm16.size() * sizeof(int16_t));
 }
 
 std::string openai_transcribe(const std::vector<float> &audio, const std::string &language) {
@@ -100,5 +134,88 @@ std::string openai_transcribe(const std::vector<float> &audio, const std::string
     }
 
     return response;
+}
+
+OpenAIRealtimeClient::OpenAIRealtimeClient(const std::string &language)
+    : m_language(language) {}
+
+OpenAIRealtimeClient::~OpenAIRealtimeClient() {
+    if (m_curl) {
+        curl_easy_cleanup(m_curl);
+    }
+    if (m_headers) {
+        curl_slist_free_all(m_headers);
+    }
+}
+
+bool OpenAIRealtimeClient::connect() {
+    std::string api_key = get_env("OPENAI_API_KEY");
+    if (api_key.empty()) {
+        fprintf(stderr, "OPENAI_API_KEY is not set\n");
+        return false;
+    }
+
+    m_curl = curl_easy_init();
+    if (!m_curl) {
+        return false;
+    }
+
+    std::string url = "wss://api.openai.com/v1/realtime?intent=transcription&model=gpt-4o-mini-transcribe&version=2025-04-01-preview";
+    curl_easy_setopt(m_curl, CURLOPT_URL, url.c_str());
+    curl_easy_setopt(m_curl, CURLOPT_CONNECT_ONLY, 2L); // 2 = websockets
+
+    std::string auth = "Authorization: Bearer " + api_key;
+    m_headers = curl_slist_append(m_headers, auth.c_str());
+    curl_easy_setopt(m_curl, CURLOPT_HTTPHEADER, m_headers);
+
+    CURLcode res = curl_easy_perform(m_curl);
+    if (res != CURLE_OK) {
+        fprintf(stderr, "OpenAI WS connect failed: %s\n", curl_easy_strerror(res));
+        return false;
+    }
+
+    // send config message
+    std::string cfg = "{\"type\":\"config\",\"model\":\"gpt-4o-mini-transcribe\",\"language\":\"" + m_language + "\"}";
+    size_t sent = 0;
+    res = curl_ws_send(m_curl, cfg.c_str(), cfg.size(), &sent, 0, CURLWS_TEXT);
+    if (res != CURLE_OK) {
+        fprintf(stderr, "OpenAI WS config failed: %s\n", curl_easy_strerror(res));
+        return false;
+    }
+    return true;
+}
+
+bool OpenAIRealtimeClient::send_audio(const std::vector<float> &audio) {
+    if (!m_curl) return false;
+    std::string b64 = pcmf32_to_base64(audio);
+    std::string msg = "{\"type\":\"audio_data\",\"data\":\"" + b64 + "\"}";
+    size_t sent = 0;
+    CURLcode res = curl_ws_send(m_curl, msg.c_str(), msg.size(), &sent, 0, CURLWS_TEXT);
+    return res == CURLE_OK;
+}
+
+bool OpenAIRealtimeClient::receive_transcript(std::string &text) {
+    if (!m_curl) return false;
+    char buf[4096];
+    size_t nread = 0;
+    const struct curl_ws_frame *meta = nullptr;
+    CURLcode res = curl_ws_recv(m_curl, buf, sizeof(buf), &nread, &meta);
+    if (res == CURLE_AGAIN || nread == 0) {
+        return false;
+    }
+    if (res != CURLE_OK) {
+        fprintf(stderr, "OpenAI WS recv failed: %s\n", curl_easy_strerror(res));
+        return false;
+    }
+
+    std::string resp(buf, nread);
+    auto pos = resp.find("\"text\":");
+    if (pos == std::string::npos) return false;
+    pos = resp.find('"', pos + 7);
+    if (pos == std::string::npos) return false;
+    size_t end = resp.find('"', pos + 1);
+    if (end == std::string::npos) return false;
+    text = resp.substr(pos + 1, end - pos - 1);
+    return true;
 }
 

--- a/src/openai_client.cpp
+++ b/src/openai_client.cpp
@@ -1,15 +1,26 @@
+#define NOMINMAX
 #define _CRT_SECURE_NO_WARNINGS
+
+#include <algorithm>
+#ifdef min
+#undef min
+#endif
+#ifdef max
+#undef max
+#endif
+
+#include <cstdint>
+#include <cstdlib>
+#include <fstream>
+#include <sstream>
+#include <curl/curl.h>
+#include <chrono>
+#include <thread>
+
 #include "openai_client.h"
 #include "common.h"
 #include "whisper.h"
 
-#include <curl/curl.h>
-#include <cstdlib>
-#include <fstream>
-#include <sstream>
-#include <algorithm>
-#include <chrono>
-#include <thread>
 
 // simple helper to read environment variable or fallback to .env file
 static std::string get_env(const std::string &key) {


### PR DESCRIPTION
## Summary
- add `OpenAIRealtimeClient` to stream audio to OpenAI's realtime transcription API over WebSocket
- send PCM audio chunks in base64 and parse transcript responses
- run dedicated API loop separate from local model inference

## Testing
- `g++ -std=c++17 -c src/openai_client.cpp -Iinclude -lcurl` (succeeds with deprecation warnings)
- `g++ -std=c++17 -c src/main.cpp -Iinclude` (fails: `SDL.h: No such file or directory`)


------
https://chatgpt.com/codex/tasks/task_e_689066f089fc832aa816995b31519113